### PR TITLE
Update client readme

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -215,9 +215,8 @@ The use cases corresponding to the different combinations of the boolean flags:
 ```js
 const deploymentOptions = {
     adminAddress: "0x123...", // If omitted, defaults to the deployer. Will be the admin of the newly created data union
-    dataUnionName: "demoName", // NOT stored anywhere, only used for address derivation
-    adminFee: 0.3, // Must be between 0...1
-    joinPartAgents: ["0x123..."], // If omitted, set by default to include the admin as well as the trusted DU DAO join-server infrastructure address
+    adminFee: 0.3, // Share of revenue allocated to the adminAddress. Must be between 0...1
+    joinPartAgents: ["0x123..."], // Addresses that can join and part members. If omitted, set by default to include the admin as well as the default join server hosted by DU DAO
     metadata: { // optional
         "information": "related to your data union",
         "canBe": ["", "anything"]
@@ -229,15 +228,13 @@ const dataUnion = await DU.deployDataUnion({
 })
 ```
 
-Streamr Core is added as a `joinPartAgent` by default so that joining with secret works using the member function `join`. If you don't plan to use `join` for "self-service joining", you can leave out Streamr Core agent by calling `deployDataUnion` e.g. with your own address as the sole joinPartAgent:
+The [Default Join Server](https://github.com/dataunions/default-join-server) hosted by the Data Union DAO is added as a `joinPartAgent` by default so that joining with secret works using the member function `join`. If you plan to run your own join server, include its address in the `joinPartAgents`:
 ```js
 const dataUnion = await DU.deployDataUnion({
-    joinPartAgents: [adminAddress],
+    joinPartAgents: [adminAddress, myJoinServerAddress],
     adminFee,
 })
 ```
-
-`dataUnionName` option exists purely for the purpose of predicting the addresses of Data Unions not yet deployed. Data Union deployment uses the [CREATE2 opcode](https://eips.ethereum.org/EIPS/eip-1014) which means a Data Union deployed by a particular address with particular "name" will have a predictable address.
 
 ### Utility functions
 In order to retrieve the client's address an async call must me made to `dataunions.getAddress`


### PR DESCRIPTION
Encountered a few outdated bits in the readme:
- Cleanup some info about the default `joinPartAgents`
- Remove outdated section about `dataUnionName` and CREATE2