### PR TITLE
ETH-405: add IPurchaseListener to DU template

### DIFF
--- a/packages/contracts/contracts/DataUnionTemplate.sol
+++ b/packages/contracts/contracts/DataUnionTemplate.sol
@@ -11,8 +11,9 @@ import "./IJoinListener.sol";
 import "./IPartListener.sol";
 import "./LeaveConditionCode.sol";
 import "./IFeeOracle.sol";
+import "./IPurchaseListener.sol";
 
-contract DataUnionTemplate is Ownable, IERC677Receiver {
+contract DataUnionTemplate is Ownable, IERC677Receiver, IPurchaseListener {
     // Used to describe both members and join part agents
     enum ActiveStatus {NONE, ACTIVE, INACTIVE}
 
@@ -234,6 +235,11 @@ contract DataUnionTemplate is Ownable, IERC677Receiver {
         }
 
         refreshRevenue();
+    }
+
+    function onPurchase(bytes32, address, uint256, uint256, uint256) external override returns (bool) {
+        refreshRevenue();
+        return true;
     }
 
     //------------------------------------------------------------

--- a/packages/contracts/contracts/IPurchaseListener.sol
+++ b/packages/contracts/contracts/IPurchaseListener.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+interface IPurchaseListener {
+	/**
+	 * Similarly to ETH transfer, returning false will decline the transaction
+	 *   (declining should probably cause revert, but that's up to the caller)
+	 * IMPORTANT: include onlyMarketplace modifier to your implementations if your logic depends on the arguments!
+	 */
+	function onPurchase(
+		bytes32 productId,
+		address subscriber,
+		uint256 endTimestamp,
+		uint256 priceDatacoin,
+		uint256 feeDatacoin
+	) external returns (bool accepted);
+}

--- a/packages/contracts/test/contracts/DataUnionTemplate.test.ts
+++ b/packages/contracts/test/contracts/DataUnionTemplate.test.ts
@@ -324,8 +324,20 @@ describe("DataUnionTemplate", () => {
         expect(await dataUnionSidechain.getWithdrawableEarnings(m[0])).to.equal(1000)
     })
 
+    it("refreshes revenue when IPurchaseListener activates", async () => {
+        const totalRevenueBefore = await dataUnionSidechain.totalRevenue()
+        await testToken.transfer(dataUnionSidechain.address, "3000")
+        const totalRevenueBefore2 = await dataUnionSidechain.totalRevenue()
+        // function onPurchase(bytes32, address, uint256, uint256, uint256) returns (bool)
+        await dataUnionSidechain.onPurchase("0x1234567812345678123456781234567812345678123456781234567812345678", o[0], "1670000000", "1000", "100")
+        const totalRevenueAfter = await dataUnionSidechain.totalRevenue()
+
+        expect(totalRevenueBefore).to.equal(totalRevenueBefore2)
+        expect(totalRevenueAfter).to.equal(totalRevenueBefore2.add("3000"))
+    })
+
     it("transferWithinContract", async () => {
-        assert(await testToken.transfer(dataUnionSidechain.address, "3000"))
+        await testToken.transfer(dataUnionSidechain.address, "3000")
         await dataUnionSidechain.refreshRevenue()
         await expect(dataUnionSidechain.connect(others[0]).transferWithinContract(m[1], "100")).to.be.revertedWith("error_notMember")
         // change after sidechain fees / ETH-141: admin receives fees and so becomes an INACTIVE member by _increaseBalance


### PR DESCRIPTION
This was previously in DataUnionMainnet that activated the bridge and called `onTokenBridged` in DataUnionSidechain. Too bad we don't really have DU + Marketplace tests at the moment :(